### PR TITLE
Update index.html

### DIFF
--- a/www.chuyu.me/index.html
+++ b/www.chuyu.me/index.html
@@ -1,4 +1,4 @@
-﻿<script language="JavaScript">
+<script language="JavaScript">
 
 var la=(navigator.language || navigator.browserLanguage).toLowerCase();
 
@@ -17,6 +17,8 @@ if(la.indexOf('zh-')==0)
 }
 else if(la.indexOf('ja-')==0)
     la = './ja/index.html';
+else if(la.indexOf('fr-')==0)
+    la = './fr/index.html';
 else
     la='./en/index.html';
 


### PR DESCRIPTION
add "fr" for French.

Note this script does not properly use the language preference order (e.g. if a user has English before Chinese) and incorrectly requires an "-" and country/region code after the language code. Standard BCP47 should be used.


This should be fixed by splitting the la and scanning items in proper to detect also "zh" alone (not just "zh-cn") or "ja" alone (not just "ja-jp") or "fr" alone (not just "fr-fr")

As well there's no minimal fallback support (e.g. "yue" fallbacks to "zh-hant"): such fallbacks should be searched after *explicit* matches for "zh", "ja", "fr", "en", by scanning again the list of prefered languages, and finally using "en" by default only if that scan for fallbacks fails.

There are common javascript libraries that perform BCP47-conforming lookups of language fallbacks according to user preferences, and it could be used to build various parts of the website