### PR TITLE
try to fix RemoveSpotlightFunFacts malfunction

### DIFF
--- a/Data.xml
+++ b/Data.xml
@@ -2558,7 +2558,7 @@
         </Default>
       </Item>
 
-      <Item Type="CheckBox" Name="#关闭锁屏时的Windows 聚焦推广（by 、Cloud.）">
+      <Item Type="CheckBox" Name="#关闭锁屏时的Windows 聚焦推广（by Asurada）">
         <Applicable>
           <OSVersion Compare=">=">10.0</OSVersion>
         </Applicable>
@@ -2567,20 +2567,20 @@
             <Applicable>
               <Or>
                 <Not>
-                  <RegExist Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable"/>
+                  <RegExist Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled"/>
                 </Not>
-                <RegExist Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="0"/>
+                <RegExist Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="0"/>
               </Or>
             </Applicable>
           </State>
           <True>
             <Activate>
-              <RegWrite Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="0"/>
+              <RegWrite Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="0"/>
             </Activate>
           </True>
           <False>
             <Activate>
-              <RegWrite Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="1"/>
+              <RegWrite Key="HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="1"/>
             </Activate>
           </False>
         </Current>
@@ -2590,20 +2590,20 @@
             <Applicable>
               <Or>
                 <Not>
-                  <RegExist Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable"/>
+                  <RegExist Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled"/>
                 </Not>
-                <RegExist Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="0"/>
+                <RegExist Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="0"/>
               </Or>
             </Applicable>
           </State>
           <True>
             <Activate>
-              <RegWrite Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="0"/>
+              <RegWrite Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="0"/>
             </Activate>
           </True>
           <False>
             <Activate>
-              <RegWrite Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="RotatingLockScreenEnable" Type="REG_DWORD" Data="1"/>
+              <RegWrite Key="HKEY_USERS\DEFAULT\Software\Microsoft\Windows\CurrentVersion\ContentDeliveryManager" Value="SubscribedContent-338387Enabled" Type="REG_DWORD" Data="1"/>
             </Activate>
           </False>
         </Default>


### PR DESCRIPTION
Inspiration from [Remove “fun” facts from Spotlight lock screen in Windows 10 Home (1803)](https://superuser.com/questions/1327459/remove-fun-facts-from-spotlight-lock-screen-in-windows-10-home-1803)

 `SubscribedContent-338387Enabled` seems to be the one for showing tips on the lock screen.

Fix #690 
Fix  #819
Fix #453