### PR TITLE
[添加规则] 将硬件时钟设置为 UTC

### DIFF
--- a/Data.xml
+++ b/Data.xml
@@ -7694,6 +7694,27 @@
           </False>
         </System>
       </Item>
+
+      <Item Type="CheckBox" Name="#将硬件时钟设置为 UTC（by chenjunyu19）">
+        <System>
+          <State>
+            <Applicable>
+              <RegExist Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation" Value="RealTimeIsUniversal" Type="REG_DWORD" Data="1"/>
+            </Applicable>
+          </State>
+          <True>
+            <Warning>#启用此选项通常是为了与其他操作系统兼容。如果你不知道此选项有何作用，请不要更改其状态。</Warning>
+            <Activate>
+              <RegWrite Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation" Value="RealTimeIsUniversal" Type="REG_DWORD" Data="1"/>
+            </Activate>
+          </True>
+          <False>
+            <Activate>
+              <RegWrite Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation" Value="RealTimeIsUniversal" Type="REG_DWORD" Data="0"/>
+            </Activate>
+          </False>
+        </System>
+      </Item>
     </Group>
   </SystemOptimization>
   <ESDDecryptKey>


### PR DESCRIPTION
`HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\TimeZoneInformation` 中的 `DWORD` 值 `RealTimeIsUniversal`。`0` 表示设置硬件时钟为本地时间，`1` 表示设置为协调世界时。

第一次写 Dism++ 规则，还麻烦大家检查一下我有没有写错。

此外，根据 ArchWiki 中的描述，早期版本 Windows 对该选项的支持有 BUG。我们应当对不同版本的系统分别处理，或者直接放弃老版本系统。但是鉴于我没有找到规则编写文档，这里又要麻烦大家了。

> #### Historical notes
> For _really old_ Windows, the above method fails, due to Windows bugs. More precisely,
> - For 64-bit versions of Windows 7 and older builds of Windows 10, there was a bug that made it necessary to have a `QWORD` value with hexadecimal value of `1` instead of a `DWORD` value. This bug has been fixed in newer builds and now only `DWORD` works.
> - Before Vista SP2, there is a bug that resets the clock to _localtime_ after resuming from the suspend/hibernation state.
> - For XP and older, there is a bug related to the daylight saving time. See [[2]](https://mskb.pkisolutions.com/kb/2687252) for details.
> - For _even older_ versions of Windows, you might want to read https://www.cl.cam.ac.uk/~mgk25/mswish/ut-rtc.html - the functionality was not even documented nor officially supported then.
> For these operating systems, it is recommended to use _localtime_.

- [System time (简体中文)#时间标准 - ArchWiki](https://wiki.archlinux.org/title/System_time_(%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87)#%E6%97%B6%E9%97%B4%E6%A0%87%E5%87%86)
- [System time#Time standard - ArchWiki](https://wiki.archlinux.org/title/System_time#Time_standard)