### PR TITLE
[系统优化] Windows To Go 选项

### DIFF
--- a/Data.xml
+++ b/Data.xml
@@ -683,7 +683,7 @@
       </Scan>
     </Item>
 
-<Item Name="#Windows Defender保护历史记录" Level="2">
+    <Item Name="#Windows Defender保护历史记录" Level="2">
       <Description>#Windows Defender保护历史记录存放了Windows Defender日志，日志过多会导致打开保护历史记录记录闪退</Description>
       <Warning>#清理后无法还原被隔离文件</Warning>
       <Group>#应用程序</Group>
@@ -2859,7 +2859,7 @@
         </System>
       </Item>
       
-    <Item Type="CheckBox" Name="#显示首次登录动画（by intionwun &amp; 组策略编辑器）">
+      <Item Type="CheckBox" Name="#显示首次登录动画（by intionwun &amp; 组策略编辑器）">
         <Applicable>
           <OSVersion Compare=">=">6.2</OSVersion>
         </Applicable>

--- a/Data.xml
+++ b/Data.xml
@@ -7694,6 +7694,26 @@
           </False>
         </System>
       </Item>
+
+      <Item Type="CheckBox" Name="Windows To Go标记(关闭以允许大版本更新)(By 玩火)">
+        <System>
+          <State>
+            <Applicable>
+              <RegExist Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control" Value="PortableOperatingSystem" Type="REG_DWORD" Data="1"/>
+            </Applicable>
+          </State>
+          <True>
+            <Activate>
+              <RegWrite Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control" Value="PortableOperatingSystem" Type="REG_DWORD" Data="1"/>
+            </Activate>
+          </True>
+          <False>
+            <Activate>
+              <RegDelete Key="HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control" Value="PortableOperatingSystem"/>
+            </Activate>
+          </False>
+        </System>
+      </Item>
     </Group>
   </SystemOptimization>
   <ESDDecryptKey>


### PR DESCRIPTION
打开选项可以让 Windows 优化在移动设备上启动的系统稳定性

关闭可以允许 Windows To Go 跨 Windows 大版本更新